### PR TITLE
사전 json 이스케이핑 문제 수정

### DIFF
--- a/src/main/kotlin/me/horyu/kkutuweb/dict/DictService.kt
+++ b/src/main/kotlin/me/horyu/kkutuweb/dict/DictService.kt
@@ -38,6 +38,6 @@ class DictService(
             }
         }
 
-        return "{\"word\":\"$word\",\"mean\":\"${word.mean}\",\"theme\":\"${word.theme}\",\"type\":\"${word.type}\"}"
+        return "{\"word\":\"${word.id}\",\"mean\":\"${word.mean.replace("\"", "\\\""))}\",\"theme\":\"${word.theme}\",\"type\":\"${word.type}\"}"
     }
 }


### PR DESCRIPTION
이슈 #3 수정

변경사항
- word는 이제 _id를 반환함
- mean은 이제 이스케이핑된 문자열을 반환함