### PR TITLE
클라이언트 기능 추가를 위한 웹서버 레이아웃/CSS 수정

### DIFF
--- a/src/main/resources/locale/message.properties
+++ b/src/main/resources/locale/message.properties
@@ -311,6 +311,7 @@ kkutu.menu.start=시작
 kkutu.menu.leave=나가기
 kkutu.menu.replay=리플레이
 kkutu.menu.leaderboard=<i class='fa fa-trophy'></i>&nbsp;랭킹
+kkutu.menu.refresh=새로고침
 kkutu.loading=불러오는 중
 kkutu.dialog.setting.title=환경 설정
 kkutu.dialog.setting.bgm-volume=배경 음악
@@ -321,6 +322,7 @@ kkutu.dialog.setting.deny-request.whisper=귓속말
 kkutu.dialog.setting.deny-request.friend=친구 추가
 kkutu.dialog.setting.game.title=게임 관련
 kkutu.dialog.setting.game.auto-ready=자동 준비
+kkutu.dialog.setting.game.allow-badword=필터 해제
 kkutu.dialog.setting.etc.title=기타
 kkutu.dialog.setting.etc.sort-user=접속자 목록 레벨 순 정렬
 kkutu.dialog.setting.etc.only-waiting=대기 중인 방만 보기

--- a/src/main/resources/locale/message_ko.properties
+++ b/src/main/resources/locale/message_ko.properties
@@ -311,6 +311,7 @@ kkutu.menu.start=시작
 kkutu.menu.leave=나가기
 kkutu.menu.replay=리플레이
 kkutu.menu.leaderboard=<i class='fa fa-trophy'></i>&nbsp;랭킹
+kkutu.menu.refresh=새로고침
 kkutu.loading=불러오는 중
 kkutu.dialog.setting.title=환경 설정
 kkutu.dialog.setting.bgm-volume=배경 음악
@@ -321,6 +322,7 @@ kkutu.dialog.setting.deny-request.whisper=귓속말
 kkutu.dialog.setting.deny-request.friend=친구 추가
 kkutu.dialog.setting.game.title=게임 관련
 kkutu.dialog.setting.game.auto-ready=자동 준비
+kkutu.dialog.setting.game.allow-badword=필터 해제
 kkutu.dialog.setting.etc.title=기타
 kkutu.dialog.setting.etc.sort-user=접속자 목록 레벨 순 정렬
 kkutu.dialog.setting.etc.only-waiting=대기 중인 방만 보기

--- a/src/main/resources/static/css/in_kkutu.css
+++ b/src/main/resources/static/css/in_kkutu.css
@@ -429,7 +429,7 @@ td.ranking-name {
     padding-top: 1px;
     font-size: 15px;
     font-weight: bold;
-    width: 190px;
+    width: 250px;
 }
 
 .profile-tag {

--- a/src/main/resources/templates/view/kkutu/kkutu.html
+++ b/src/main/resources/templates/view/kkutu/kkutu.html
@@ -61,6 +61,8 @@
                 <h4 th:text="#{kkutu.dialog.setting.game.title}"></h4>
                 <th:block
                         layout:replace="~{view/kkutu/option::settingOption(id='auto-ready',text=#{kkutu.dialog.setting.game.auto-ready})}"/>
+                <th:block
+                        layout:replace="~{view/kkutu/option::settingOption(id='allow-badword',text=#{kkutu.dialog.setting.game.allow-badword})}"/>
             </div>
             <div class="dialog-bar">
                 <h4 th:text="#{kkutu.dialog.setting.etc.title}"></h4>

--- a/src/main/resources/templates/view/kkutu/menu.html
+++ b/src/main/resources/templates/view/kkutu/menu.html
@@ -50,4 +50,6 @@
             th:text="#{kkutu.menu.replay}"></button>
     <button class="for-lobby" id="LeaderboardBtn" style="display: none; background-color: #FFADD3;"
             th:utext="#{kkutu.menu.leaderboard}"></button>
+    <button class="for-lobby" id="RefreshBtn" style=" display: none; background-color: #FF7F7F;"
+            th:utext="#{kkutu.menu.refresh}"></button>
 </div>


### PR DESCRIPTION
JS단 수정의 경우 개발팀 내부 방으로 링크 업로드하였습니다.

변경 내역
* 상단에 새로고침 버튼을 추가하였습니다. (방 캐싱에 의한 유령방을 덜 볼 수 있도록 하기 위함)
* 채팅 필터링을 비활성화 할 수 있도록 설정하였습니다. (이를 응용하여 필터링 단계를 조절 할 수 있도록 수정 가능)
* 단어 대결, 자음퀴즈 등의 주제 선택이 가능한 모드의 방에서, 게임 규칙 란에 커서를 올리면 주제를 미리 볼 수 있게 하였습니다.
* 유저 프로필에서 닉네임 및 태그가 잘리는 현상을 개선하였습니다.